### PR TITLE
Fix player creation when email is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ game you pick from the players stored in the database.
 ```
 POST /locations  - add a location
 GET  /locations  - list locations
-POST /players    - add a player (requires a location ID)
+POST /players    - add a player (requires email and a location ID)
 GET  /players    - list players
 POST /games      - start a game with existing players
 ```

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
   <h2>Add Player</h2>
   <form id="newPlayerForm">
     <input type="text" id="playerName" placeholder="Player Name" required />
+    <input type="email" id="playerEmail" placeholder="Email Address" required />
     <select id="playerLocation" required></select>
     <button type="submit">Add Player</button>
   </form>
@@ -108,13 +109,15 @@ document.getElementById('newLocationForm').addEventListener('submit', async func
 document.getElementById('newPlayerForm').addEventListener('submit', async function(e) {
   e.preventDefault();
   const name = document.getElementById('playerName').value;
+  const email = document.getElementById('playerEmail').value;
   const locationId = parseInt(document.getElementById('playerLocation').value, 10);
   await fetch('/players', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, locationId })
+    body: JSON.stringify({ name, email, locationId })
   });
   document.getElementById('playerName').value = '';
+  document.getElementById('playerEmail').value = '';
   loadPlayers();
 });
 

--- a/server.js
+++ b/server.js
@@ -40,15 +40,16 @@ app.get('/players', async (req, res) => {
 
 // Create new player
 app.post('/players', async (req, res) => {
-  const { name, locationId } = req.body;
+  const { name, email, locationId } = req.body;
   try {
     const pool = await getPool();
     const result = await pool.request()
       .input('name', sql.NVarChar, name)
+      .input('email', sql.NVarChar, email)
       .input('locationId', sql.Int, locationId)
-      .query(`INSERT INTO Players (Name, _Locations_ID)
+      .query(`INSERT INTO Players (Name, EmailAddress, _Locations_ID)
               OUTPUT INSERTED._Players_ID
-              VALUES (@name, @locationId)`);
+              VALUES (@name, @email, @locationId)`);
     res.json({ playerId: result.recordset[0]._Players_ID });
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- support storing player email addresses
- add email field to the player form
- document email in API overview

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d4c0b20108321b9d5574b29f62010