### PR TITLE
Implement win tracking and auto game completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This is a simple web application to track cornhole games. It exposes a small API
 Each player belongs to one of our company locations. The app does not require a location when starting a game because it is part of the player profile.
 
 The API now also lets you create and list players and locations. When starting a
-game you pick from the players stored in the database.
+game you pick from the players stored in the database. Games automatically end
+when a team reaches **21 points**. The winning team is stored in the `Games`
+table and each player's win/loss record is updated.
 
 ## Prerequisites
 
@@ -54,5 +56,7 @@ POST /players    - add a player (requires email and a location ID)
 GET  /players    - list players
 POST /games      - start a game with existing players
 ```
+
+Games end automatically when a team scores 21 points.
 
 This code is intentionally lightweight for hackathon use. Feel free to expand upon it!

--- a/public/index.html
+++ b/public/index.html
@@ -61,6 +61,7 @@
     </thead>
     <tbody></tbody>
   </table>
+  <p id="winner" style="display:none; font-weight:bold;"></p>
 </div>
 
 <script>
@@ -139,6 +140,8 @@ document.getElementById('newGameForm').addEventListener('submit', async function
   document.getElementById('gameForm').style.display = 'none';
   document.getElementById('eventForm').style.display = 'block';
   document.querySelector('.scoreboard').style.display = 'block';
+  document.getElementById('winner').style.display = 'none';
+  loadEvents();
 });
 
 document.getElementById('addEventForm').addEventListener('submit', async function(e) {
@@ -162,6 +165,8 @@ async function loadEvents() {
   const tbody = document.querySelector('#eventsTable tbody');
   tbody.innerHTML = '';
   let turn = 1;
+  let t1Total = 0;
+  let t2Total = 0;
   json.events.forEach(ev => {
     if(ev.EventType === 'turn') {
       const row = document.createElement('tr');
@@ -175,8 +180,33 @@ async function loadEvents() {
       row.appendChild(tdT1);
       row.appendChild(tdT2);
       tbody.appendChild(row);
+      t1Total += ev.PointsTeam1;
+      t2Total += ev.PointsTeam2;
     }
   });
+
+  const totalRow = document.createElement('tr');
+  const tdLabel = document.createElement('td');
+  tdLabel.textContent = 'Total';
+  const tdT1Total = document.createElement('td');
+  tdT1Total.textContent = t1Total;
+  const tdT2Total = document.createElement('td');
+  tdT2Total.textContent = t2Total;
+  totalRow.appendChild(tdLabel);
+  totalRow.appendChild(tdT1Total);
+  totalRow.appendChild(tdT2Total);
+  tbody.appendChild(totalRow);
+
+  if(json.game.Status === 'complete') {
+    document.getElementById('eventForm').style.display = 'none';
+    const winnerEl = document.getElementById('winner');
+    const team = json.game.Winner === 1 ? 'Team 1' : 'Team 2';
+    winnerEl.textContent = team + ' wins!';
+    winnerEl.style.display = 'block';
+  } else {
+    document.getElementById('eventForm').style.display = 'block';
+    document.getElementById('winner').style.display = 'none';
+  }
 }
 
 // Initialize dropdowns on page load


### PR DESCRIPTION
## Summary
- add logic to finish a game once a team hits 21 points
- store game winner and update player win/loss record
- return running score from the game API
- show totals and final winner in the front‑end
- document new behavior in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d50fddff88321aa041dd6d13adfb6